### PR TITLE
feat(build): configura build docker para diferentes ambientes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 # Porta exposta da aplicação
 APP_EXTERNAL_PORT=80
+
+# Ambiente: development ou production
+NODE_ENV=development

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
 # Stage 1: Build da aplicação Angular
 FROM node:24-alpine AS build
 
+ARG NODE_ENV=production
+
 WORKDIR /app
 
 COPY package*.json ./
 
-RUN npm ci --silent
+RUN npm ci --include=dev --silent
 
 COPY . .
 
-RUN npm run build --prod
+RUN if [ "$NODE_ENV" = "development" ]; then \
+        npm run build:dev; \
+    else \
+        npm run build; \
+    fi
 
 # Stage 2: Servir com Nginx
 FROM nginx:alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
         build:
             context: .
             dockerfile: Dockerfile
+            args:
+                - NODE_ENV=${NODE_ENV:-production}
         container_name: app-biblioteca_angular
         ports:
             - "${APP_EXTERNAL_PORT}:80"
@@ -10,7 +12,7 @@ services:
         networks:
             - biblioteca-app-angular-network
         environment:
-            - NODE_ENV=production
+            - NODE_ENV=${NODE_ENV:-production}
 
 networks:
     biblioteca-app-angular-network:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
         "ng": "ng",
         "start": "ng serve",
         "build": "ng build",
+        "build:dev": "ng build --configuration development",
         "watch": "ng build --watch --configuration development",
         "test": "ng test",
         "lint": "ng lint",


### PR DESCRIPTION
- adiciona variável de ambiente NODE_ENV no docker-compose e Dockerfile para controlar o tipo de build.
- altera comando de instalação de dependências para incluir dependências de desenvolvimento (ng).
- adiciona script "build:dev" para gerar build de desenvolvimento.
- implementa condicional no Dockerfile para executar o build de acordo com o ambiente (desenvolvimento ou produção).

closes #16